### PR TITLE
Fix typo in zoom default status message

### DIFF
--- a/layouts/partials/session/watch-zoom.html
+++ b/layouts/partials/session/watch-zoom.html
@@ -6,5 +6,5 @@
         </button>
     </a>
 {{ else }}
-    <span class="label label-primary">Zoom link will be avaiable very soon</span>
+    <span class="label label-primary">Zoom link will be available very soon</span>
 {{ end}}


### PR DESCRIPTION
Fix typo in "Zoom link will be avaiable very soon".
`.. from : avaiable`
`.... to : available`