### PR TITLE
feat(legacy): move to 2020.open-security-summit.org

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseurl                 = "https://open-security-summit.org/"
+baseurl                 = "https://2020.open-security-summit.org/"
 title                   = "Open Security Summit"
 theme                   = "oss-owasp"
 languageCode            = "en-us"
@@ -59,7 +59,7 @@ paginate = 10
     url = "/tracks/"
 
 [[menu.main]]
-    name = "Trainings"
+    name = "Training"
     identifier = "training"
     pre = "<i class='fa fa-road'></i>&nbsp;"
     weight = 4

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,1 @@
-open-security-summit.org
+2020.open-security-summit.org


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

This will move to the new subdomain 2020.open-security-summit.org.